### PR TITLE
correct typo giving a partial argument match

### DIFF
--- a/R/match.R
+++ b/R/match.R
@@ -81,7 +81,7 @@ re_matches <- matches <- m <- function(data, pattern, global = FALSE, options = 
     ends[not_matched] <- NA_integer_
 
     indexes <- unlist(lapply(seq_len(ncol(res)), function(x) {
-        seq(x, b = ncol(res), length.out = 3)
+        seq(x, by = ncol(res), length.out = 3)
     }))
 
     full <- data.frame(res, starts, ends, stringsAsFactors = FALSE, check.names = FALSE)[, indexes, drop = FALSE]


### PR DESCRIPTION
Please the following!
https://kevinushey.github.io/blog/2015/02/02/rprofile-essentials/

I now warn with partial argument matches, and discovered this when I used lintr.